### PR TITLE
style: configure formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  locals_without_parens: [inspect: 1, spec: 2],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/games_engine/grid/coordinate.ex
+++ b/lib/games_engine/grid/coordinate.ex
@@ -18,10 +18,8 @@ defmodule GamesEngine.Grid.Coordinate do
   | 1 | 4 | 7 | --> |1,0|1,1|1,2|
   | 2 | 5 | 8 |     |2,0|2,1|2,2|
   """
-  @spec(
-    ind_2_sub(non_neg_integer(), {non_neg_integer(), non_neg_integer()}) :: t(),
-    {:error, String.t()}
-  )
+  @spec ind_2_sub(non_neg_integer(), {non_neg_integer(), non_neg_integer()}) :: t(),
+        {:error, String.t()}
   def ind_2_sub(ind, {rows, cols}) do
     with(
       :ok <- NumericValidations.non_neg_integer(ind),

--- a/lib/games_engine/validations/grid_validations.ex
+++ b/lib/games_engine/validations/grid_validations.ex
@@ -6,10 +6,8 @@ defmodule GamesEngine.Validations.GridValidations do
   @doc """
   Ensures a linear index is within the bounds of the supplied grid
   """
-  @spec(
-    ind_within_bounds(non_neg_integer(), {non_neg_integer(), non_neg_integer()}) :: :ok,
-    {:error, String.t()}
-  )
+  @spec ind_within_bounds(non_neg_integer(), {non_neg_integer(), non_neg_integer()}) :: :ok,
+        {:error, String.t()}
   def ind_within_bounds(ind, {rows, cols}) do
     if ind >= rows * cols,
       do: {:error, "#{ind} exceeds the bounds of a #{rows}x#{cols} board"},

--- a/lib/games_engine/validations/numeric_validations.ex
+++ b/lib/games_engine/validations/numeric_validations.ex
@@ -6,9 +6,9 @@ defmodule GamesEngine.Validations.NumericValidations do
   @doc """
   Ensures the input is a non-negative integer
   """
-  @spec(non_neg_integer(term()) :: :ok, {:error, String.t()})
+  @spec non_neg_integer(term()) :: :ok, {:error, String.t()}
   def non_neg_integer(input) when is_integer(input) and input >= 0, do: :ok
 
   def non_neg_integer(input),
-    do: {:error, "Expected non-negative integer, received #{inspect(input)}"}
+    do: {:error, "Expected non-negative integer, received #{inspect input}"}
 end


### PR DESCRIPTION
configure `locals_without_parens` to include `inspect/1` and `spec/2`