### PR TITLE
feat[QOL]: tile attribute modifier functions

### DIFF
--- a/lib/games_engine/grid/tile.ex
+++ b/lib/games_engine/grid/tile.ex
@@ -27,4 +27,41 @@ defmodule GamesEngine.Grid.Tile do
       %{tile | attributes: attributes}
     end
   end
+
+  @doc """
+  Replaces the entire attributes map of a `%Tile{}` with a new map
+  """
+  @spec replace_attributes(t(), map()) :: t()
+  def replace_attributes(%__MODULE__{} = tile, attributes) when is_map(attributes) do
+    %{tile | attributes: attributes}
+  end
+
+  def replace_attributes(_tile, _attributes), do: {:error, "expected map for :attributes"}
+
+  @doc """
+  Updates an existing attribute of a `%Tile{}`
+  """
+  @spec update_attribute(t(), atom(), term()) :: t()
+  def update_attribute(%__MODULE__{} = tile, key, value) do
+    updated_attributes =
+      tile
+      |> Map.get(:attributes)
+      |> Map.replace(key, value)
+
+    %{tile | attributes: updated_attributes}
+  end
+
+  @doc """
+  Adds a new attributes to a `%Tile{}`
+  Will not overwrite the attribute if it already exists
+  """
+  @spec put_new_attribute(t(), atom(), term()) :: t()
+  def put_new_attribute(%__MODULE__{} = tile, key, value) do
+    updated_attributes =
+      tile
+      |> Map.get(:attributes)
+      |> Map.put_new(key, value)
+
+    %{tile | attributes: updated_attributes}
+  end
 end

--- a/lib/games_engine/grid/tile.ex
+++ b/lib/games_engine/grid/tile.ex
@@ -55,8 +55,8 @@ defmodule GamesEngine.Grid.Tile do
   Adds a new attributes to a `%Tile{}`
   Will not overwrite the attribute if it already exists
   """
-  @spec put_new_attribute(t(), atom(), term()) :: t()
-  def put_new_attribute(%__MODULE__{} = tile, key, value) do
+  @spec add_attribute(t(), atom(), term()) :: t()
+  def add_attribute(%__MODULE__{} = tile, key, value) do
     updated_attributes =
       tile
       |> Map.get(:attributes)

--- a/test/games_engine/grid/tile_test.exs
+++ b/test/games_engine/grid/tile_test.exs
@@ -17,4 +17,62 @@ defmodule GamesEngine.Grid.TileTest do
       assert %Tile{coordinate: %Coordinate{row: 3, col: 3}} = Tile.new({3, 3})
     end
   end
+
+  describe "replace_attributes/2" do
+    setup do
+      [
+        tile: %Tile{
+          coordinate: nil,
+          attributes: %{}
+        }
+      ]
+    end
+
+    test "returns error tuple if new attributes arg is not a map", %{tile: tile} do
+      assert {:error, "expected map for :attributes"} = Tile.replace_attributes(tile, "not a map")
+    end
+
+    test "successfully updates the attributes of a tile", %{tile: tile} do
+      new_attributes = %{a: 1, b: 2}
+      assert %Tile{attributes: ^new_attributes} = Tile.replace_attributes(tile, new_attributes)
+    end
+  end
+
+  describe "update_attribute/3" do
+    setup do
+      [
+        tile: %Tile{
+          coordinate: nil,
+          attributes: %{a: 1}
+        }
+      ]
+    end
+
+    test "returns tile with existing attributes if new attribute supplied", %{tile: tile} do
+      assert tile == Tile.update_attribute(tile, :new_key, 2)
+    end
+
+    test "successfully updates an existing attribute", %{tile: tile} do
+      assert %Tile{attributes: %{a: 2}} = Tile.update_attribute(tile, :a, 2)
+    end
+  end
+
+  describe "put_new_attribute/3" do
+    setup do
+      [
+        tile: %Tile{
+          coordinate: nil,
+          attributes: %{a: 1}
+        }
+      ]
+    end
+
+    test "returns tile with existing attributes if existing attribute supplied", %{tile: tile} do
+      assert tile == Tile.put_new_attribute(tile, :a, 3)
+    end
+
+    test "successfully adds a new attribute", %{tile: tile} do
+      assert %Tile{attributes: %{a: 1, b: 2}} = Tile.put_new_attribute(tile, :b, 2)
+    end
+  end
 end

--- a/test/games_engine/grid/tile_test.exs
+++ b/test/games_engine/grid/tile_test.exs
@@ -57,7 +57,7 @@ defmodule GamesEngine.Grid.TileTest do
     end
   end
 
-  describe "put_new_attribute/3" do
+  describe "add_attribute/3" do
     setup do
       [
         tile: %Tile{
@@ -68,11 +68,11 @@ defmodule GamesEngine.Grid.TileTest do
     end
 
     test "returns tile with existing attributes if existing attribute supplied", %{tile: tile} do
-      assert tile == Tile.put_new_attribute(tile, :a, 3)
+      assert tile == Tile.add_attribute(tile, :a, 3)
     end
 
     test "successfully adds a new attribute", %{tile: tile} do
-      assert %Tile{attributes: %{a: 1, b: 2}} = Tile.put_new_attribute(tile, :b, 2)
+      assert %Tile{attributes: %{a: 1, b: 2}} = Tile.add_attribute(tile, :b, 2)
     end
   end
 end


### PR DESCRIPTION
## Description

Add functions to the `Tile` module for updating tile attributes
- `replace_attributes/2` -> overwrite the existing attributes map with a new one
- `update_attribute/3` -> update a single attribute value
- `add_attribute/3` -> add a new key value pair to the attributes

Ticket: [GE-27](https://kwardynski.atlassian.net/browse/GE-27)


[GE-27]: https://kwardynski.atlassian.net/browse/GE-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ