### PR TITLE
feat(QOL): update tile attributes from the grid module

### DIFF
--- a/lib/games_engine/grid.ex
+++ b/lib/games_engine/grid.ex
@@ -5,6 +5,7 @@ defmodule GamesEngine.Grid do
 
   alias GamesEngine.Grid.Coordinate
   alias GamesEngine.Grid.Tile
+  alias GamesEngine.Validations.GridValidations
   alias GamesEngine.Validations.NumericValidations
 
   @type t :: %__MODULE__{}
@@ -47,5 +48,60 @@ defmodule GamesEngine.Grid do
       tile = Tile.new({row, col}, attributes)
       Map.put(tiles, ind, tile)
     end)
+  end
+
+  @doc """
+  Replaces the attributes of a tile
+  """
+  @spec replace_tile_attributes(t(), non_neg_integer(), map()) :: t() | {:error, String.t()}
+  def replace_tile_attributes(%__MODULE__{} = grid, ind, attributes) do
+    with(
+      :ok <- GridValidations.ind_within_bounds(ind, grid),
+      {:ok, tiles} <- fetch_grid_tiles(grid),
+      %Tile{} = updated_tile <- Tile.replace_attributes(tiles[ind], attributes)
+    ) do
+      updated_tiles = %{tiles | ind => updated_tile}
+      %{grid | tiles: updated_tiles}
+    end
+  end
+
+  @doc """
+  Updates an existing attribute of a `%Tile{}`
+  """
+  @spec update_tile_attribute(t(), non_neg_integer(), atom(), any()) :: t() | {:error, String.t()}
+  def update_tile_attribute(%__MODULE__{} = grid, ind, key, value) do
+    with(
+      :ok <- GridValidations.ind_within_bounds(ind, grid),
+      {:ok, tiles} <- fetch_grid_tiles(grid),
+      %Tile{} = updated_tile <- Tile.update_attribute(tiles[ind], key, value)
+    ) do
+      updated_tiles = %{tiles | ind => updated_tile}
+      %{grid | tiles: updated_tiles}
+    end
+  end
+
+  @doc """
+  Adds a new attributes to a `%Tile{}`
+  Will not overwrite the attribute if it already exists
+  """
+  @spec add_tile_attribute(t(), non_neg_integer(), atom(), any()) :: t() | {:error, String.t()}
+  def add_tile_attribute(%__MODULE__{} = grid, ind, key, value) do
+    with(
+      :ok <- GridValidations.ind_within_bounds(ind, grid),
+      {:ok, tiles} <- fetch_grid_tiles(grid),
+      %Tile{} = updated_tile <- Tile.add_attribute(tiles[ind], key, value)
+    ) do
+      updated_tiles = %{tiles | ind => updated_tile}
+      %{grid | tiles: updated_tiles}
+    end
+  end
+
+  @spec fetch_grid_tiles(t()) :: {:ok, list(Tile.t())} | {:error, String.t()}
+  defp fetch_grid_tiles(grid) do
+    tiles = Map.get(grid, :tiles, nil)
+
+    if is_nil(tiles),
+      do: {:error, "grid has no tiles"},
+      else: {:ok, tiles}
   end
 end

--- a/lib/games_engine/grid/tile.ex
+++ b/lib/games_engine/grid/tile.ex
@@ -31,7 +31,7 @@ defmodule GamesEngine.Grid.Tile do
   @doc """
   Replaces the entire attributes map of a `%Tile{}` with a new map
   """
-  @spec replace_attributes(t(), map()) :: t()
+  @spec replace_attributes(t(), map()) :: t() | {:error, String.t()}
   def replace_attributes(%__MODULE__{} = tile, attributes) when is_map(attributes) do
     %{tile | attributes: attributes}
   end
@@ -41,7 +41,7 @@ defmodule GamesEngine.Grid.Tile do
   @doc """
   Updates an existing attribute of a `%Tile{}`
   """
-  @spec update_attribute(t(), atom(), term()) :: t()
+  @spec update_attribute(t(), atom(), any()) :: t()
   def update_attribute(%__MODULE__{} = tile, key, value) do
     updated_attributes =
       tile
@@ -55,7 +55,7 @@ defmodule GamesEngine.Grid.Tile do
   Adds a new attributes to a `%Tile{}`
   Will not overwrite the attribute if it already exists
   """
-  @spec add_attribute(t(), atom(), term()) :: t()
+  @spec add_attribute(t(), atom(), any()) :: t()
   def add_attribute(%__MODULE__{} = tile, key, value) do
     updated_attributes =
       tile

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule GamesEngine.MixProject do
       app: :games_engine,
       version: "0.2.1",
       elixir: "~> 1.14",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       description: description(),
@@ -41,6 +42,10 @@ defmodule GamesEngine.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/games_engine/grid/tile_test.exs
+++ b/test/games_engine/grid/tile_test.exs
@@ -32,7 +32,7 @@ defmodule GamesEngine.Grid.TileTest do
       assert {:error, "expected map for :attributes"} = Tile.replace_attributes(tile, "not a map")
     end
 
-    test "successfully updates the attributes of a tile", %{tile: tile} do
+    test "successfully replaces the attributes of a tile", %{tile: tile} do
       new_attributes = %{a: 1, b: 2}
       assert %Tile{attributes: ^new_attributes} = Tile.replace_attributes(tile, new_attributes)
     end

--- a/test/games_engine/grid_test.exs
+++ b/test/games_engine/grid_test.exs
@@ -1,6 +1,8 @@
 defmodule GamesEngine.GridTest do
   use ExUnit.Case, async: true
 
+  import GamesEngine.GridFixtures
+
   alias GamesEngine.Grid
 
   describe "new/2" do
@@ -43,6 +45,84 @@ defmodule GamesEngine.GridTest do
       Enum.each(tiles, fn {_, %{attributes: tile_attributes}} ->
         assert tile_attributes == default_attributes
       end)
+    end
+  end
+
+  describe "replace_tile_attributes/3" do
+    test "returns error tuple if new attributes arg is not a map" do
+      grid = grid_fixture(3, 3)
+
+      assert {:error, "expected map for :attributes"} =
+               Grid.replace_tile_attributes(grid, 3, "invalid_input")
+    end
+
+    test "successfully replaces the attributes of a tile" do
+      grid = grid_fixture(3, 3)
+      attributes = %{key: "value"}
+
+      assert %Grid{
+               tiles: %{
+                 3 => %{attributes: replaced_tile_attributes}
+               }
+             } = Grid.replace_tile_attributes(grid, 3, attributes)
+
+      assert replaced_tile_attributes == attributes
+    end
+  end
+
+  describe "update_tile_attribute/4" do
+    test "no change to tile attributes if a new attribute is supplied" do
+      attributes = %{key: "value"}
+      grid = grid_fixture(3, 3, attributes)
+
+      assert %Grid{
+               tiles: %{
+                 3 => %{attributes: tile_attributes}
+               }
+             } = Grid.update_tile_attribute(grid, 3, :new_key, "new_value")
+
+      assert tile_attributes == attributes
+    end
+
+    test "successfully updates an existing tile attribute" do
+      attributes = %{key: "value"}
+      grid = grid_fixture(3, 3, attributes)
+
+      assert %Grid{
+               tiles: %{
+                 3 => %{attributes: updated_tile_attributes}
+               }
+             } = Grid.update_tile_attribute(grid, 3, :key, "new_value")
+
+      assert updated_tile_attributes == %{key: "new_value"}
+    end
+  end
+
+  describe "add_tile_attribute/4" do
+    test "no change to tile attributes if a existing attribute is supplied" do
+      attributes = %{key: "value"}
+      grid = grid_fixture(3, 3, attributes)
+
+      assert %Grid{
+               tiles: %{
+                 3 => %{attributes: tile_attributes}
+               }
+             } = Grid.add_tile_attribute(grid, 3, :key, "new_value")
+
+      assert tile_attributes == attributes
+    end
+
+    test "successfully adds a new attribute to the tile" do
+      attributes = %{key: "value"}
+      grid = grid_fixture(3, 3, attributes)
+
+      assert %Grid{
+               tiles: %{
+                 3 => %{attributes: updated_tile_attributes}
+               }
+             } = Grid.add_tile_attribute(grid, 3, :new_key, "new_value")
+
+      assert updated_tile_attributes == %{key: "value", new_key: "new_value"}
     end
   end
 end

--- a/test/support/fixtures/grid_fixtures.ex
+++ b/test/support/fixtures/grid_fixtures.ex
@@ -1,0 +1,15 @@
+defmodule GamesEngine.GridFixtures do
+  @moduledoc """
+  This module defines test helpers for creating grid entities
+  """
+
+  alias GamesEngine.Grid
+
+  @doc """
+  Generate a grid
+  """
+  def grid_fixture(rows, cols, tile_attributes \\ %{}) do
+    Grid.new(rows, cols)
+    |> Grid.populate(tile_attributes)
+  end
+end


### PR DESCRIPTION
## Description

- Allow for replacing, updating, and adding to the attributes of Grid's tile
- Some misc fixes
  - incorrect typespecs
  - test names

Ticket: [GE-28](https://kwardynski.atlassian.net/browse/GE-28)


[GE-28]: https://kwardynski.atlassian.net/browse/GE-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ